### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#WordPress Theme Puma
+# WordPress Theme Puma
 
 [中文版本](https://github.com/bigfa/Puma/blob/master/README_CN.md)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-#WordPress 主题 Puma
+# WordPress 主题 Puma
 
 [English Version](https://github.com/bigfa/Puma/blob/master/README.md)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
